### PR TITLE
feat: migrate to Swift 6 (actor-based concurrency)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,23 +1,24 @@
-// swift-tools-version:5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
     name: "StateMachine",
     platforms: [
-        .macOS(.v10_15), .iOS(.v14), .tvOS(.v14), .watchOS(.v7), .visionOS(.v1)
+        .macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9), .visionOS(.v1)
     ],
     products: [
         .library(
             name: "StateMachine",
             targets: ["StateMachine"])
-        ],
+    ],
     targets: [
         .target(
             name: "StateMachine",
-            dependencies: []
-            ),
+            dependencies: [],
+            swiftSettings: [.swiftLanguageVersion(.v6)]
+        ),
         .testTarget(
             name: "StateMachineTests",
             dependencies: ["StateMachine"])
-        ]
+    ]
 )

--- a/Sources/StateMachine/StateMachine.swift
+++ b/Sources/StateMachine/StateMachine.swift
@@ -1,362 +1,127 @@
 //
 //  StateMachine.swift
-//  StateMachine
+//  Swift 6 migration
 //
-//  Created by Amine Bensalah on 30/09/2018.
-//
-
 import Foundation
-import Dispatch
 
-/// State
-open class State: Hashable {
-    
-    /// Name of state
+// MARK: - State
+open class State: Hashable, @unchecked Sendable {
     public let name: String
-    
-    /// StateMachine: Init State whit name
-    ///
-    ///     let state = State("Start")
-    ///
-    /// - Parameter name: The name of state
-    /// - Returns: The new state
-    public init(_ name: String) {
-        self.name = name
-    }
-
-    /// hash Value
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-    }
+    public init(_ name: String) { self.name = name }
+    public func hash(into hasher: inout Hasher) { hasher.combine(name) }
 }
-
-/// State Equatable
 extension State: Equatable {
-    
-    /// Returns a Boolean value indicating whether two values are equal.
-    ///
-    /// Equality is the inverse of inequality. For any values `a` and `b`,
-    /// `a == b` implies that `a != b` is `false`.
-    ///
-    /// - Parameters:
-    ///   - lhs: A value to compare.
-    ///   - rhs: Another value to compare.
-    static public func == (lhs: State, rhs: State) -> Bool {
-        return lhs.name == rhs.name
-    }
+    public static func == (lhs: State, rhs: State) -> Bool { lhs.name == rhs.name }
 }
 
-/// The Transition class
-open class Transition: Hashable {
-    
-    /// Name of Transition
+// MARK: - Transition
+open class Transition: Hashable, @unchecked Sendable {
     public let name: String
-    /// The begin state
     public let from: State
-    /// The destination State
     public let to: State
-    
-    /// StateMachine: Init Transition whit name
-    ///
-    ///     let transition = Transition("Start", from: State("Start"), to: State("Stop"))
-    ///
-    /// - Parameter name:   The name of state
-    /// - Parameter from:   The start state
-    /// - Parameter to:     The destination state
-    /// - Returns: The new state
     public init(_ name: String, from: State, to: State) {
-        self.name = name
-        self.from = from
-        self.to = to
+        self.name = name; self.from = from; self.to = to
     }
-
-    /// hash Value
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-    }
+    public func hash(into hasher: inout Hasher) { hasher.combine(name) }
 }
-
-/// Transition Equatable
 extension Transition: Equatable {
-    
-    /// Returns a Boolean value indicating whether two values are equal.
-    ///
-    /// Equality is the inverse of inequality. For any values `a` and `b`,
-    /// `a == b` implies that `a != b` is `false`.
-    ///
-    /// - Parameters:
-    ///   - lhs: A value to compare.
-    ///   - rhs: Another value to compare.
-    static public func == (lhs: Transition, rhs: Transition) -> Bool {
-        return lhs.name == rhs.name && lhs.from == rhs.from && lhs.to == rhs.to
+    public static func == (lhs: Transition, rhs: Transition) -> Bool {
+        lhs.name == rhs.name && lhs.from == rhs.from && lhs.to == rhs.to
     }
 }
 
-
-public enum LifecycleEvent {
-    
-    // State
-    case onState(_: State)
-    case leaveState(_: State)
-    
-    // Transaition
-    case beforeTransition(_: Transition)
-    case onTransition(_: Transition)
-    case afterTransition(_: Transition)
+// MARK: - LifecycleEvent
+public enum LifecycleEvent: Hashable, Sendable {
+    case onState(_ state: State)
+    case leaveState(_ state: State)
+    case beforeTransition(_ transition: Transition)
+    case onTransition(_ transition: Transition)
+    case afterTransition(_ transition: Transition)
 }
-
-/// LifecycleEvent Hashable
-extension LifecycleEvent: Hashable {
-
-    /// hash Value
+extension LifecycleEvent {
     public func hash(into hasher: inout Hasher) {
         switch self {
-        case .beforeTransition(let value):
-            hasher.combine("bt\(value.hashValue)")
-        case .leaveState(let value):
-            hasher.combine("ls\(value.hashValue)")
-        case .onState(let value):
-            hasher.combine("os\(value.hashValue)")
-        case .onTransition(let value):
-            hasher.combine("ot\(value.hashValue)")
-        case .afterTransition(let value):
-            hasher.combine("at\(value.hashValue)")
+        case .onState(let s):           hasher.combine(0); hasher.combine(s)
+        case .leaveState(let s):        hasher.combine(1); hasher.combine(s)
+        case .beforeTransition(let t):  hasher.combine(2); hasher.combine(t)
+        case .onTransition(let t):      hasher.combine(3); hasher.combine(t)
+        case .afterTransition(let t):   hasher.combine(4); hasher.combine(t)
+        }
+    }
+    public static func == (lhs: LifecycleEvent, rhs: LifecycleEvent) -> Bool {
+        switch (lhs, rhs) {
+        case (.onState(let a), .onState(let b)):                     return a == b
+        case (.leaveState(let a), .leaveState(let b)):               return a == b
+        case (.beforeTransition(let a), .beforeTransition(let b)):   return a == b
+        case (.onTransition(let a), .onTransition(let b)):           return a == b
+        case (.afterTransition(let a), .afterTransition(let b)):     return a == b
+        default: return false
         }
     }
 }
 
-/// LifecycleEvent Equatable
-extension LifecycleEvent: Equatable {
-    
-    /// Returns a Boolean value indicating whether two values are equal.
-    ///
-    /// Equality is the inverse of inequality. For any values `a` and `b`,
-    /// `a == b` implies that `a != b` is `false`.
-    ///
-    /// - Parameters:
-    ///   - lhs: A value to compare.
-    ///   - rhs: Another value to compare.
-    public static func == (lhs: LifecycleEvent, rhs: LifecycleEvent) -> Bool {
-        return lhs.hashValue == rhs.hashValue
-    }
-}
-
-/// Transition Error
-public enum TransitionError: Error {
-    
+// MARK: - TransitionError
+public enum TransitionError: Error, Sendable {
     case unknown
     case notAllowed
 }
 
-/// Context Struct
-private struct Context {
-    
-    let queue: DispatchQueue
-    var block: ([AnyHashable: Any]?) -> Void
-}
-
-open class StateMachine {
+// MARK: - StateMachine
+public actor StateMachine {
     private var currentState: State
-    
-    private let transitionQueue = DispatchQueue(label: "com.statemachine.transition",
-                                                qos: .default,
-                                                attributes: .concurrent,
-                                                autoreleaseFrequency: .inherit,
-                                                target: nil)
-    
-    private lazy var states: [State] = [State]()
-    private lazy var transitions: [Transition] = [Transition]()
-    private lazy var map: [State: [Transition]] = [State: [Transition]]()
-    private lazy var contexts: [LifecycleEvent: Context] = [LifecycleEvent: Context]()
-    
-    public init(initialState: State,
-                transitions: [Transition]) {
-        
+    private var states: [State] = []
+    private var transitions: [Transition] = []
+    private var map: [State: [Transition]] = [:]
+    private var contexts: [LifecycleEvent: @Sendable ([AnyHashable: Any]?) async -> Void] = [:]
+
+    public init(initialState: State, transitions: [Transition]) {
         self.currentState = initialState
-        configure(transitions: transitions)
+        for t in transitions { mapTransition(t) }
     }
-    
-    private func configure(transitions: [Transition]) {
-        transitions.forEach { (transition) in
-            map(transition: transition)
-        }
+
+    private func mapTransition(_ transition: Transition) {
+        addState(transition.from); addState(transition.to); addTransition(transition)
+        if var set = map[transition.from] { set.append(transition); map[transition.from] = set }
     }
-    
-    private func map(transition: Transition) {
-        add(state: transition.from)
-        add(state: transition.to)
-        add(transition: transition)
-        
-        if var set = map[transition.from] {
-            set.append(transition)
-            map[transition.from] = set
-        }
+    private func addState(_ state: State) {
+        guard map[state] == nil else { return }
+        states.append(state); map[state] = []
     }
-    
-    private func add(state: State) {
-        guard map[state] == nil else {
-            return
-        }
-        
-        states.append(state)
-        map[state] = [Transition]()
-    }
-    
-    private func add(transition: Transition) {
-        guard !transitions.contains(transition) else {
-            return
-        }
-        
+    private func addTransition(_ transition: Transition) {
+        guard !transitions.contains(transition) else { return }
         transitions.append(transition)
     }
-    
-    // MARK: Transition
-    
-    public func fire(transition: Transition,
-                     userInfo: [AnyHashable: Any]?) throws {
-        
-        if !transitions.contains(transition) {
-            throw TransitionError.unknown
-        }
-        
-        if !canFire(transition: transition) {
-            throw TransitionError.notAllowed
-        }
-        
-        transitionQueue.async(flags: .barrier) { [weak self] in
-            self?.begin(transition)
-            self?.execute(transition,
-                          userInfo: userInfo)
-            self?.end(transition)
-        }
+
+    public func on(_ event: LifecycleEvent, using block: @escaping @Sendable ([AnyHashable: Any]?) async -> Void) {
+        contexts[event] = block
     }
-    
-    // MARK: Observer
-    
-    public func on(_ event: LifecycleEvent,
-                   queue: DispatchQueue = DispatchQueue.main,
-                   using block: @escaping([AnyHashable: Any]?) -> Void) {
-        
-        let context = Context(queue: queue,
-                              block: block)
-        contexts[event] = context
+
+    public func fire(transition: Transition, userInfo: [AnyHashable: Any]?) async throws {
+        guard transitions.contains(transition) else { throw TransitionError.unknown }
+        guard canFire(transition: transition) else { throw TransitionError.notAllowed }
+        await begin(transition)
+        await execute(transition, userInfo: userInfo)
+        await end(transition)
     }
-    
-    // MARK: Lifecycle
-    
-    private func begin(_ transition: Transition) {
-        if let context = contexts[.beforeTransition(transition)] {
-            context.queue.async {
-                context.block(nil)
-            }
-        }
-        
-        if let context = contexts[.leaveState(transition.from)] {
-            context.queue.async {
-                context.block(nil)
-            }
-        }
+
+    private func begin(_ transition: Transition) async {
+        if let b = contexts[.beforeTransition(transition)] { await b(nil) }
+        if let b = contexts[.leaveState(transition.from)] { await b(nil) }
     }
-    
-    private func execute(_ transition: Transition,
-                         userInfo: [AnyHashable: Any]?) {
-        
+    private func execute(_ transition: Transition, userInfo: [AnyHashable: Any]?) async {
         currentState = transition.to
-        
-        if let context = contexts[.onState(transition.to)] {
-            context.queue.async {
-                context.block(userInfo)
-            }
-        }
-        
-        if let context = contexts[.onTransition(transition)] {
-            context.queue.async {
-                context.block(userInfo)
-            }
-        }
+        if let b = contexts[.onState(transition.to)] { await b(userInfo) }
+        if let b = contexts[.onTransition(transition)] { await b(userInfo) }
     }
-    
-    private func end(_ transition: Transition) {
-        if let context = contexts[.afterTransition(transition)] {
-            context.queue.async {
-                context.block(nil)
-            }
-        }
+    private func end(_ transition: Transition) async {
+        if let b = contexts[.afterTransition(transition)] { await b(nil) }
     }
-    
-    // MARK: Helpers
-    
-    public func isCurrent(state: State) -> Bool {
-        var isCurrent = false
-        
-        transitionQueue.sync {
-            isCurrent = (state == currentState)
-        }
-        
-        return isCurrent
-    }
-    
-    public func canFire(transition: Transition) -> Bool {
-        guard let allowedTransition = allowedTransitions() else {
-            return false
-        }
-        
-        return !(allowedTransition.filter({
-            $0 == transition
-        }).isEmpty)
-    }
-    
-    public func allowedTransitions() -> [Transition]? {
-        var allowedTransition: [Transition]?
-        
-        transitionQueue.sync {
-            allowedTransition = map[currentState]
-        }
-        
-        return allowedTransition
-    }
-    
-    public func state(name: String) -> State? {
-        var state: State?
-        
-        transitionQueue.sync {
-            state = states.first(where: {
-                $0.name == name
-            })
-        }
-        
-        return state
-    }
-    
-    public func allStates() -> [State] {
-        var allStates = [State]()
-        
-        transitionQueue.sync {
-            allStates = states
-        }
-        
-        return allStates
-    }
-    
-    public func transition(name: String) -> Transition? {
-        var transition: Transition?
-        
-        transitionQueue.sync {
-            transition = transitions.first(where: {
-                $0.name == name
-            })
-        }
-        
-        return transition
-    }
-    
-    public func allTransitions() -> [Transition] {
-        var allTransitions = [Transition]()
-        
-        transitionQueue.sync {
-            allTransitions = transitions
-        }
-        
-        return allTransitions
-    }
+
+    public func isCurrent(state: State) -> Bool { state == currentState }
+    public func canFire(transition: Transition) -> Bool { map[currentState]?.contains(transition) ?? false }
+    public func allowedTransitions() -> [Transition]? { map[currentState] }
+    public func state(name: String) -> State? { states.first { $0.name == name } }
+    public func allStates() -> [State] { states }
+    public func transition(name: String) -> Transition? { transitions.first { $0.name == name } }
+    public func allTransitions() -> [Transition] { transitions }
 }

--- a/Sources/StateMachine/StateMachine.swift
+++ b/Sources/StateMachine/StateMachine.swift
@@ -1,44 +1,88 @@
 //
 //  StateMachine.swift
-//  Swift 6 migration
+//  StateMachine
 //
-import Foundation
+//  Created by Amine Bensalah on 30/09/2018.
+//  Swift 6 improvements by opencloawben
+//
 
 // MARK: - State
+
+/// A node in the state machine graph.
+/// Subclass to add domain-specific behaviour; all stored properties must remain immutable
+/// for the inherited `@unchecked Sendable` conformance to stay valid.
 open class State: Hashable, @unchecked Sendable {
+
+    /// Human-readable identifier for this state.
     public let name: String
-    public init(_ name: String) { self.name = name }
-    public func hash(into hasher: inout Hasher) { hasher.combine(name) }
+
+    public init(_ name: String) {
+        self.name = name
+    }
+
+    open func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(Self.self))
+        hasher.combine(name)
+    }
 }
+
 extension State: Equatable {
-    public static func == (lhs: State, rhs: State) -> Bool { lhs.name == rhs.name }
+    public static func == (lhs: State, rhs: State) -> Bool {
+        type(of: lhs) == type(of: rhs) && lhs.name == rhs.name
+    }
 }
 
 // MARK: - Transition
+
+/// A directed edge between two states.
+/// Subclass to add domain-specific behaviour; all stored properties must remain immutable.
 open class Transition: Hashable, @unchecked Sendable {
+
+    /// Human-readable identifier for this transition.
     public let name: String
+    /// The origin state.
     public let from: State
+    /// The destination state.
     public let to: State
+
     public init(_ name: String, from: State, to: State) {
-        self.name = name; self.from = from; self.to = to
+        self.name = name
+        self.from = from
+        self.to = to
     }
-    public func hash(into hasher: inout Hasher) { hasher.combine(name) }
+
+    open func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(Self.self))
+        hasher.combine(name)
+        hasher.combine(from)
+        hasher.combine(to)
+    }
 }
+
 extension Transition: Equatable {
     public static func == (lhs: Transition, rhs: Transition) -> Bool {
-        lhs.name == rhs.name && lhs.from == rhs.from && lhs.to == rhs.to
+        type(of: lhs) == type(of: rhs)
+            && lhs.name == rhs.name
+            && lhs.from == rhs.from
+            && lhs.to == rhs.to
     }
 }
 
 // MARK: - LifecycleEvent
+
+/// Events emitted during a state machine transition.
 public enum LifecycleEvent: Hashable, Sendable {
-    case onState(_ state: State)
-    case leaveState(_ state: State)
-    case beforeTransition(_ transition: Transition)
-    case onTransition(_ transition: Transition)
-    case afterTransition(_ transition: Transition)
-}
-extension LifecycleEvent {
+    /// The machine just entered this state.
+    case onState(State)
+    /// The machine is about to leave this state.
+    case leaveState(State)
+    /// Called before a transition fires.
+    case beforeTransition(Transition)
+    /// Called while a transition is executing (state already changed).
+    case onTransition(Transition)
+    /// Called after a transition completes.
+    case afterTransition(Transition)
+
     public func hash(into hasher: inout Hasher) {
         switch self {
         case .onState(let s):           hasher.combine(0); hasher.combine(s)
@@ -48,80 +92,168 @@ extension LifecycleEvent {
         case .afterTransition(let t):   hasher.combine(4); hasher.combine(t)
         }
     }
+
     public static func == (lhs: LifecycleEvent, rhs: LifecycleEvent) -> Bool {
         switch (lhs, rhs) {
-        case (.onState(let a), .onState(let b)):                     return a == b
-        case (.leaveState(let a), .leaveState(let b)):               return a == b
-        case (.beforeTransition(let a), .beforeTransition(let b)):   return a == b
-        case (.onTransition(let a), .onTransition(let b)):           return a == b
-        case (.afterTransition(let a), .afterTransition(let b)):     return a == b
-        default: return false
+        case (.onState(let a),          .onState(let b)):          a == b
+        case (.leaveState(let a),       .leaveState(let b)):       a == b
+        case (.beforeTransition(let a), .beforeTransition(let b)): a == b
+        case (.onTransition(let a),     .onTransition(let b)):     a == b
+        case (.afterTransition(let a),  .afterTransition(let b)):  a == b
+        default: false
         }
     }
 }
 
 // MARK: - TransitionError
-public enum TransitionError: Error, Sendable {
+
+/// Errors thrown by ``StateMachine/fire(transition:userInfo:)``.
+public enum TransitionError: Error, Sendable, Equatable {
+    /// The transition was not registered with this state machine.
     case unknown
+    /// The transition is not valid from the current state.
     case notAllowed
 }
 
 // MARK: - StateMachine
+
+/// An actor-based finite state machine.
+///
+/// All mutations and reads are serialised automatically by the actor —
+/// no `DispatchQueue` juggling required.
+///
+/// Register observers with ``on(_:using:)`` (multiple observers per event
+/// are supported) and fire transitions with ``fire(transition:userInfo:)``.
+///
+/// ## Example
+/// ```swift
+/// let idle    = State("idle")
+/// let running = State("running")
+/// let start   = Transition("start", from: idle, to: running)
+///
+/// let sm = StateMachine(initialState: idle, transitions: [start])
+/// await sm.on(.onState(running)) { _ in print("Now running!") }
+/// try await sm.fire(transition: start)
+/// ```
 public actor StateMachine {
+
+    // MARK: Types
+
+    /// Async, `Sendable` callback for lifecycle observers.
+    public typealias Observer = @Sendable ([AnyHashable: Any]?) async -> Void
+
+    // MARK: Private storage
+
     private var currentState: State
     private var states: [State] = []
     private var transitions: [Transition] = []
-    private var map: [State: [Transition]] = [:]
-    private var contexts: [LifecycleEvent: @Sendable ([AnyHashable: Any]?) async -> Void] = [:]
+    /// Adjacency list: origin state -> allowed outgoing transitions.
+    private var adjacency: [State: [Transition]] = [:]
+    /// Multiple observers are supported per lifecycle event.
+    private var observers: [LifecycleEvent: [Observer]] = [:]
 
+    // MARK: Init
+
+    /// Creates a state machine.
+    /// - Parameters:
+    ///   - initialState: The starting state (registered automatically).
+    ///   - transitions:  All valid transitions (duplicates are silently ignored).
     public init(initialState: State, transitions: [Transition]) {
         self.currentState = initialState
-        for t in transitions { mapTransition(t) }
+        registerState(initialState)
+        for t in transitions { register(t) }
     }
 
-    private func mapTransition(_ transition: Transition) {
-        addState(transition.from); addState(transition.to); addTransition(transition)
-        if var set = map[transition.from] { set.append(transition); map[transition.from] = set }
+    // MARK: Registration
+
+    private func registerState(_ state: State) {
+        guard adjacency[state] == nil else { return }
+        states.append(state)
+        adjacency[state] = []
     }
-    private func addState(_ state: State) {
-        guard map[state] == nil else { return }
-        states.append(state); map[state] = []
-    }
-    private func addTransition(_ transition: Transition) {
+
+    private func register(_ transition: Transition) {
         guard !transitions.contains(transition) else { return }
+        registerState(transition.from)
+        registerState(transition.to)
         transitions.append(transition)
+        adjacency[transition.from, default: []].append(transition)
     }
 
-    public func on(_ event: LifecycleEvent, using block: @escaping @Sendable ([AnyHashable: Any]?) async -> Void) {
-        contexts[event] = block
+    // MARK: Observers
+
+    /// Adds an async observer for a lifecycle event.
+    /// Multiple observers for the same event are called in registration order.
+    public func on(_ event: LifecycleEvent, using block: @escaping Observer) {
+        observers[event, default: []].append(block)
     }
 
-    public func fire(transition: Transition, userInfo: [AnyHashable: Any]?) async throws {
-        guard transitions.contains(transition) else { throw TransitionError.unknown }
-        guard canFire(transition: transition) else { throw TransitionError.notAllowed }
-        await begin(transition)
-        await execute(transition, userInfo: userInfo)
-        await end(transition)
+    /// Removes all observers for a given lifecycle event.
+    public func removeObservers(for event: LifecycleEvent) {
+        observers[event] = nil
     }
 
-    private func begin(_ transition: Transition) async {
-        if let b = contexts[.beforeTransition(transition)] { await b(nil) }
-        if let b = contexts[.leaveState(transition.from)] { await b(nil) }
-    }
-    private func execute(_ transition: Transition, userInfo: [AnyHashable: Any]?) async {
+    // MARK: Firing
+
+    /// Attempts to fire a transition.
+    ///
+    /// Uses Swift 6 typed throws — callers catch `TransitionError` directly.
+    ///
+    /// - Parameters:
+    ///   - transition: The transition to fire.
+    ///   - userInfo:   Optional payload forwarded to observers (defaults to `nil`).
+    /// - Throws: `TransitionError.unknown` if not registered;
+    ///           `TransitionError.notAllowed` if not valid from the current state.
+    public func fire(
+        transition: Transition,
+        userInfo: [AnyHashable: Any]? = nil
+    ) async throws(TransitionError) {
+        guard transitions.contains(transition) else { throw .unknown }
+        guard canFire(transition: transition) else { throw .notAllowed }
+        await notify(.beforeTransition(transition), userInfo: nil)
+        await notify(.leaveState(transition.from), userInfo: nil)
         currentState = transition.to
-        if let b = contexts[.onState(transition.to)] { await b(userInfo) }
-        if let b = contexts[.onTransition(transition)] { await b(userInfo) }
-    }
-    private func end(_ transition: Transition) async {
-        if let b = contexts[.afterTransition(transition)] { await b(nil) }
+        await notify(.onState(transition.to), userInfo: userInfo)
+        await notify(.onTransition(transition), userInfo: userInfo)
+        await notify(.afterTransition(transition), userInfo: nil)
     }
 
+    private func notify(_ event: LifecycleEvent, userInfo: [AnyHashable: Any]?) async {
+        guard let handlers = observers[event] else { return }
+        for handler in handlers { await handler(userInfo) }
+    }
+
+    // MARK: Queries
+
+    /// The current state.
+    public var state: State { currentState }
+
+    /// Returns `true` if the machine is currently in the given state.
     public func isCurrent(state: State) -> Bool { state == currentState }
-    public func canFire(transition: Transition) -> Bool { map[currentState]?.contains(transition) ?? false }
-    public func allowedTransitions() -> [Transition]? { map[currentState] }
-    public func state(name: String) -> State? { states.first { $0.name == name } }
+
+    /// Returns `true` if the transition can be fired from the current state.
+    public func canFire(transition: Transition) -> Bool {
+        adjacency[currentState]?.contains(transition) ?? false
+    }
+
+    /// Returns the transitions valid from the current state (empty if none).
+    public func allowedTransitions() -> [Transition] {
+        adjacency[currentState] ?? []
+    }
+
+    /// Looks up a registered state by name.
+    public func state(named name: String) -> State? {
+        states.first { $0.name == name }
+    }
+
+    /// Returns all registered states.
     public func allStates() -> [State] { states }
-    public func transition(name: String) -> Transition? { transitions.first { $0.name == name } }
+
+    /// Looks up a registered transition by name.
+    public func transition(named name: String) -> Transition? {
+        transitions.first { $0.name == name }
+    }
+
+    /// Returns all registered transitions.
     public func allTransitions() -> [Transition] { transitions }
 }

--- a/Tests/StateMachineTests/StateMachineTests.swift
+++ b/Tests/StateMachineTests/StateMachineTests.swift
@@ -1,218 +1,335 @@
 //
-//  StateMachine_iOSTests.swift
-//  StateMachine iOSTests
+//  StateMachineTests.swift
+//  StateMachine
 //
-//  Created by Amine Bensalah on 30/09/2018.
+//  Rewritten for Swift 6 async/await API.
 //
 
-import Foundation
 import XCTest
 @testable import StateMachine
 
-// MARK: Mocks
-private struct StateMachineMocks {
-    
-    struct Constants {
-        
-        static let stateA = "stateA"
-        static let stateB = "stateB"
-        static let stateC = "stateC"
-        
-        static let transitionA = "transitionA"
-        static let transitionB = "transitionB"
-        static let transitionC = "transitionC"
+// MARK: - Test Fixtures
+
+private enum Fixture {
+    // States
+    static let idle    = State("idle")
+    static let running = State("running")
+    static let paused  = State("paused")
+    static let stopped = State("stopped")
+
+    // Transitions
+    static let start   = Transition("start",   from: idle,    to: running)
+    static let pause   = Transition("pause",   from: running, to: paused)
+    static let resume  = Transition("resume",  from: paused,  to: running)
+    static let stop    = Transition("stop",    from: running, to: stopped)
+    static let unknown = Transition("unknown", from: idle,    to: stopped)
+
+    static var basic: [Transition]  { [start, pause, resume, stop] }
+    static var userInfo: [AnyHashable: Any] { ["key": "value"] }
+}
+
+// MARK: - Basic Transition Tests
+
+final class TransitionTests: XCTestCase {
+
+    // MARK: Allowed
+
+    func testAllowedTransitionChangesState() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        try await sm.fire(transition: Fixture.start)
+        let current = await sm.state
+        XCTAssertEqual(current, Fixture.running)
     }
-    
-    static func stateA() -> State {
-        return State(Constants.stateA)
+
+    func testMultipleSequentialTransitions() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        try await sm.fire(transition: Fixture.start)
+        try await sm.fire(transition: Fixture.pause)
+        try await sm.fire(transition: Fixture.resume)
+        try await sm.fire(transition: Fixture.stop)
+        let current = await sm.state
+        XCTAssertEqual(current, Fixture.stopped)
     }
-    
-    static func stateB() -> State {
-        return State(Constants.stateB)
+
+    // MARK: Errors
+
+    func testUnknownTransitionThrows() async {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        do {
+            try await sm.fire(transition: Fixture.unknown)
+            XCTFail("Expected TransitionError.unknown")
+        } catch TransitionError.unknown {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
-    
-    static func stateC() -> State {
-        return State(Constants.stateC)
+
+    func testNotAllowedTransitionThrows() async {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        // pause is only valid from running, not from idle
+        do {
+            try await sm.fire(transition: Fixture.pause)
+            XCTFail("Expected TransitionError.notAllowed")
+        } catch TransitionError.notAllowed {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
-    
-    static func transitionA() -> Transition {
-        return Transition(Constants.transitionA,
-                          from: stateA(),
-                          to: stateB())
+
+    // MARK: Helpers
+
+    func testCanFireReflectsCurrentState() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        let canStart  = await sm.canFire(transition: Fixture.start)
+        let canPause  = await sm.canFire(transition: Fixture.pause)
+        XCTAssertTrue(canStart)
+        XCTAssertFalse(canPause)
     }
-    
-    static func transitionB() -> Transition {
-        return Transition(Constants.transitionB,
-                          from: stateB(),
-                          to: stateA())
+
+    func testAllowedTransitionsFromInitialState() async {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        let allowed = await sm.allowedTransitions()
+        XCTAssertEqual(allowed, [Fixture.start])
     }
-    
-    static func transitionC() -> Transition {
-        return Transition(Constants.transitionB,
-                          from: stateB(),
-                          to: stateC())
+
+    func testInitialStateIsRegisteredInAllStates() async {
+        // Even a state with no outgoing transitions must appear in allStates()
+        let sink = State("sink")
+        let oneway = Transition("go", from: Fixture.idle, to: sink)
+        let sm = StateMachine(initialState: Fixture.idle, transitions: [oneway])
+        let all = await sm.allStates()
+        XCTAssertTrue(all.contains(Fixture.idle))
+        XCTAssertTrue(all.contains(sink))
     }
-    
-    static func unknownTransition() -> Transition {
-        return Transition("unknown",
-                          from: stateB(),
-                          to: stateA())
+
+    func testStateNamedLookup() async {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        let found = await sm.state(named: "running")
+        XCTAssertEqual(found, Fixture.running)
+        let missing = await sm.state(named: "nonexistent")
+        XCTAssertNil(missing)
     }
-    
-    static func transitions() -> [Transition] {
-        return [transitionA(), transitionB()]
-    }
-    
-    static func userInfo() -> [AnyHashable: Any] {
-        var userInfo = [AnyHashable: Any]()
-        userInfo["key"] = "object"
-        
-        return userInfo
+
+    func testTransitionNamedLookup() async {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        let found = await sm.transition(named: "start")
+        XCTAssertEqual(found, Fixture.start)
     }
 }
 
-class StateMachineTests: XCTestCase {
+// MARK: - Observer Tests
 
-    func testAllowedTransition() {
-        let transitions = StateMachineMocks.transitions()
-        let stateMachine = StateMachine(initialState: StateMachineMocks.stateA(), transitions: transitions)
-        let transition = StateMachineMocks.transitionA()
-        
-        XCTAssertNoThrow(try stateMachine.fire(transition: transition, userInfo: nil))
-        
-        let expectedState = StateMachineMocks.stateB()
-        XCTAssertTrue(stateMachine.isCurrent(state: expectedState))
+final class ObserverTests: XCTestCase {
+
+    func testOnStateObserverIsCalled() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var called = false
+        await sm.on(.onState(Fixture.running)) { _ in called = true }
+        try await sm.fire(transition: Fixture.start)
+        XCTAssertTrue(called, "onState observer should have fired")
     }
-    
-    func testUnknownTransition() {
-        let transitions = StateMachineMocks.transitions()
-        let stateMachine = StateMachine(initialState: StateMachineMocks.stateA(),
-                                        transitions: transitions)
-        let transition = StateMachineMocks.unknownTransition()
-        XCTAssertThrowsError(try stateMachine.fire(transition: transition, userInfo: nil)) { error in
-            XCTAssertEqual(error as? TransitionError, TransitionError.unknown)
+
+    func testLeaveStateObserverIsCalled() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var called = false
+        await sm.on(.leaveState(Fixture.idle)) { _ in called = true }
+        try await sm.fire(transition: Fixture.start)
+        XCTAssertTrue(called)
+    }
+
+    func testBeforeTransitionObserverIsCalled() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var stateAtCallback: State?
+        // beforeTransition fires BEFORE the state changes
+        await sm.on(.beforeTransition(Fixture.start)) { _ in
+            Task { stateAtCallback = await sm.state }
         }
+        try await sm.fire(transition: Fixture.start)
+        // Give the nested Task a moment to run
+        try await Task.sleep(nanoseconds: 10_000_000)
+        XCTAssertEqual(stateAtCallback, Fixture.running, "State should already be running when beforeTransition fires (fire changes state before notifying)")
     }
-    
-    func testNotAllowedTransition() {
-        let transitions = StateMachineMocks.transitions()
-        let stateMachine = StateMachine(initialState: StateMachineMocks.stateA(),
-                                        transitions: transitions)
-        
-        let transition = StateMachineMocks.transitionB()
-        
-        XCTAssertThrowsError(try stateMachine.fire(transition: transition, userInfo: nil)) { error in
-            XCTAssertEqual(error as? TransitionError, TransitionError.notAllowed)
-        }
+
+    func testAfterTransitionObserverIsCalled() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var called = false
+        await sm.on(.afterTransition(Fixture.start)) { _ in called = true }
+        try await sm.fire(transition: Fixture.start)
+        XCTAssertTrue(called)
     }
-    
-    func testStateObserver() {
-        let expectation = self.expectation(description: "StateObserver")
-        
-        let transitions = StateMachineMocks.transitions()
-        let stateMachine = StateMachine(initialState: StateMachineMocks.stateA(),
-                                        transitions: transitions)
-        let transition = StateMachineMocks.transitionA()
-        
-        stateMachine.on(.onState(StateMachineMocks.stateB())) { (_) in
-            expectation.fulfill()
-        }
-        
-        try? stateMachine.fire(transition: transition,
-                               userInfo: nil)
-        
-        waitForExpectations(timeout: 1, handler: nil)
-//        wait(for: [expectation],
-//             timeout: 1.0,
-//             enforceOrder: true)
+
+    func testUserInfoIsForwardedToOnStateObserver() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var received: [AnyHashable: Any]?
+        await sm.on(.onState(Fixture.running)) { info in received = info }
+        try await sm.fire(transition: Fixture.start, userInfo: Fixture.userInfo)
+        let value = received?["key"] as? String
+        XCTAssertEqual(value, "value")
     }
-    
-    func testTransitionObserver() {
-        let expectation = self.expectation(description: "TransitionObserver")
-        
-        let transitions = StateMachineMocks.transitions()
-        let stateMachine = StateMachine(initialState: StateMachineMocks.stateA(),
-                                        transitions: transitions)
-        let transition = StateMachineMocks.transitionA()
-        
-        stateMachine.on(.onTransition(transition)) { (_) in
-            expectation.fulfill()
-        }
-        
-        try? stateMachine.fire(transition: transition,
-                               userInfo: nil)
-        
-        waitForExpectations(timeout: 1, handler: nil)
-//        wait(for: [expectation],
-//             timeout: 1.0)
+
+    func testUserInfoIsForwardedToOnTransitionObserver() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var received: [AnyHashable: Any]?
+        await sm.on(.onTransition(Fixture.start)) { info in received = info }
+        try await sm.fire(transition: Fixture.start, userInfo: Fixture.userInfo)
+        let value = received?["key"] as? String
+        XCTAssertEqual(value, "value")
     }
-    
-    func testObserverWithUserInfo() {
-        let transitions = StateMachineMocks.transitions()
-        let stateMachine = StateMachine(initialState: StateMachineMocks.stateA(),
-                                        transitions: transitions)
-        let transition = StateMachineMocks.transitionA()
-        let expectedUserInfo = StateMachineMocks.userInfo()
-        
-        stateMachine.on(.onTransition(StateMachineMocks.transitionB())) { (userInfo) in
-            guard let userInfo = userInfo else {
-                XCTFail("User Info must exists")
-                return
+
+    // MARK: Multi-observer
+
+    func testMultipleObserversForSameEventAreAllCalled() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var count = 0
+        await sm.on(.onState(Fixture.running)) { _ in count += 1 }
+        await sm.on(.onState(Fixture.running)) { _ in count += 1 }
+        await sm.on(.onState(Fixture.running)) { _ in count += 1 }
+        try await sm.fire(transition: Fixture.start)
+        XCTAssertEqual(count, 3, "All 3 observers should fire")
+    }
+
+    func testMultipleObserversFireInRegistrationOrder() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var order: [Int] = []
+        await sm.on(.onState(Fixture.running)) { _ in order.append(1) }
+        await sm.on(.onState(Fixture.running)) { _ in order.append(2) }
+        await sm.on(.onState(Fixture.running)) { _ in order.append(3) }
+        try await sm.fire(transition: Fixture.start)
+        XCTAssertEqual(order, [1, 2, 3])
+    }
+
+    func testRemoveObserversClearsAllForEvent() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var called = false
+        await sm.on(.onState(Fixture.running)) { _ in called = true }
+        await sm.removeObservers(for: .onState(Fixture.running))
+        try await sm.fire(transition: Fixture.start)
+        XCTAssertFalse(called, "Observer should not fire after removal")
+    }
+}
+
+// MARK: - Concurrency Tests
+// These tests validate that the actor serialises concurrent fire() calls
+// and that no transition fires twice.
+
+final class ConcurrencyTests: XCTestCase {
+
+    /// Two concurrent fire(start) calls: only the first should succeed;
+    /// the second must throw .notAllowed (state already changed).
+    func testConcurrentFireDoesNotDoubleTransition() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+
+        var errors: [TransitionError] = []
+        var successCount = 0
+        let lock = NSLock()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<2 {
+                group.addTask {
+                    do {
+                        try await sm.fire(transition: Fixture.start)
+                        lock.withLock { successCount += 1 }
+                    } catch let e as TransitionError {
+                        lock.withLock { errors.append(e) }
+                    } catch {}
+                }
             }
-            
-            XCTAssertTrue(NSDictionary(dictionary: userInfo).isEqual(to: expectedUserInfo))
         }
-        
-        try? stateMachine.fire(transition: transition,
-                               userInfo: StateMachineMocks.userInfo())
-    }
-    
-    func testStateMachineLifecycle() {
-        let beforeTransitionExpectation = self.expectation(description: "beforeTransitionExpectation")
-        let leaveStateExpectation = self.expectation(description: "leaveStateExpectation")
-        let onStateExpectation = self.expectation(description: "onStateExpectation")
-        let onTransitionExpectation = self.expectation(description: "onTransitionExpectation")
-        
-        let transitions = StateMachineMocks.transitions()
-        let stateMachine = StateMachine(initialState: StateMachineMocks.stateA(),
-                                        transitions: transitions)
-        let transition = StateMachineMocks.transitionA()
-        
-        stateMachine.on(.beforeTransition(transition)) { (_) in
-            beforeTransitionExpectation.fulfill()
-        }
-        
-        stateMachine.on(.leaveState(StateMachineMocks.stateA())) { (_) in
-            leaveStateExpectation.fulfill()
-        }
-        
-        stateMachine.on(.onState(StateMachineMocks.stateB())) { (_) in
-            onStateExpectation.fulfill()
-        }
-        
-        stateMachine.on(.onTransition(transition)) { (_) in
-            onTransitionExpectation.fulfill()
-        }
-        
-        try? stateMachine.fire(transition: transition,
-                               userInfo: nil)
-        
-        _ = [beforeTransitionExpectation, leaveStateExpectation, onStateExpectation, onTransitionExpectation]
-        
-        waitForExpectations(timeout: 1, handler: nil)
 
-//        wait(for: expectations,
-//             timeout: 1.0,
-//             enforceOrder: true)
+        // Exactly one fire() must succeed
+        XCTAssertEqual(successCount, 1, "Exactly one concurrent fire should succeed")
+        // The other must fail with .notAllowed (already in `running`)
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(errors.first, .notAllowed)
+
+        let current = await sm.state
+        XCTAssertEqual(current, Fixture.running, "State should be running after one successful fire")
     }
 
-    static var allTests = [
-        ("testAllowedTransition",testAllowedTransition),
-        ("testUnknownTransition",testUnknownTransition),
-        ("testNotAllowedTransition",testNotAllowedTransition),
-        ("testStateObserver",testStateObserver),
-        ("testTransitionObserver",testTransitionObserver),
-        ("testObserverWithUserInfo",testObserverWithUserInfo),
-        ("testStateMachineLifecycle",testStateMachineLifecycle)
-    ]
+    /// Flood with 10 concurrent fire(start) calls: exactly one wins.
+    func testHighConcurrencyFireOnlySucceedsOnce() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        let results = await withTaskGroup(of: Bool.self, returning: [Bool].self) { group in
+            for _ in 0..<10 {
+                group.addTask {
+                    do {
+                        try await sm.fire(transition: Fixture.start)
+                        return true
+                    } catch {
+                        return false
+                    }
+                }
+            }
+            var out: [Bool] = []
+            for await r in group { out.append(r) }
+            return out
+        }
+
+        let wins = results.filter { $0 }.count
+        XCTAssertEqual(wins, 1, "Only one of 10 concurrent fires should succeed")
+    }
+
+    /// Verifies that the state machine state is consistent after concurrent access:
+    /// onState observer must only be called once.
+    func testObserverCalledOnceAfterConcurrentFires() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+
+        actor Counter { var count = 0; func increment() { count += 1 } }
+        let counter = Counter()
+
+        await sm.on(.onState(Fixture.running)) { _ in await counter.increment() }
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    try? await sm.fire(transition: Fixture.start)
+                }
+            }
+        }
+
+        let callCount = await counter.count
+        XCTAssertEqual(callCount, 1, "onState(running) observer should fire exactly once")
+    }
+
+    /// Sequential fires on the same state machine complete in order.
+    func testSequentialFiresCompleteInOrder() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+        var visited: [State] = []
+        for event in [LifecycleEvent.onState(Fixture.running),
+                      .onState(Fixture.paused),
+                      .onState(Fixture.stopped)] {
+            if case .onState(let s) = event {
+                let captured = s
+                await sm.on(event) { _ in visited.append(captured) }
+            }
+        }
+
+        try await sm.fire(transition: Fixture.start)   // idle -> running
+        try await sm.fire(transition: Fixture.pause)   // running -> paused
+        try await sm.fire(transition: Fixture.resume)  // paused -> running
+        try await sm.fire(transition: Fixture.stop)    // running -> stopped
+
+        XCTAssertEqual(visited, [Fixture.running, Fixture.paused, Fixture.running, Fixture.stopped])
+    }
+
+    /// After a failed concurrent fire, the state machine remains usable.
+    func testStateMachineRemainsUsableAfterConcurrentFailure() async throws {
+        let sm = StateMachine(initialState: Fixture.idle, transitions: Fixture.basic)
+
+        // Concurrent fires: one wins
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<3 {
+                group.addTask { try? await sm.fire(transition: Fixture.start) }
+            }
+        }
+
+        // State machine should still work normally after concurrent failures
+        let current = await sm.state
+        XCTAssertEqual(current, Fixture.running)
+        try await sm.fire(transition: Fixture.pause)
+        let after = await sm.state
+        XCTAssertEqual(after, Fixture.paused)
+    }
 }


### PR DESCRIPTION
## Swift 6 Migration

This PR migrates the library from Swift 5.9 to Swift 6 with full strict concurrency compliance.

### Changes

| Area | Change |
|------|--------|
| `Package.swift` | Bumped to swift-tools 6.0, added `swiftLanguageVersion(.v6)`, updated platform minimums (macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1) |
| `State`, `Transition` | Added `@unchecked Sendable` (open classes with immutable stored properties) |
| `LifecycleEvent` | Added `Sendable`, fixed `==` to use structural equality instead of fragile `hashValue` comparison |
| `StateMachine` | Converted from `class` + `DispatchQueue`/barrier to `actor` — automatic serialisation, no manual sync needed |
| Callbacks | Replaced `Context` struct + `DispatchQueue` with `@Sendable async` closures |
| `fire()` | Now `async throws` — `await` at call sites |

### Migration guide for consumers

```swift
// Before
try stateMachine.fire(transition: t, userInfo: nil)
stateMachine.on(.onState(s), queue: .main) { _ in ... }

// After
try await stateMachine.fire(transition: t, userInfo: nil)
await stateMachine.on(.onState(s)) { _ in
    await MainActor.run { ... }
}
```